### PR TITLE
feat: 닉네임 입력 과정 추가 및 메인페이지 구성 보완

### DIFF
--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -21,21 +21,6 @@ class SignUpForm(UserCreationForm):
         widget=forms.TextInput(attrs={'placeholder': '본인의 학번을 입력해주세요.'}),
         help_text='숫자만 입력해주세요.'
     )
-    nickname = forms.CharField(
-        max_length=30,
-        label='닉네임',
-        widget=forms.TextInput(attrs={'placeholder': '닉네임을 입력해주세요.'}),
-        help_text='중복되지 않는 닉네임을 입력해주세요.'
-    )
-    image = forms.ImageField(
-        label='프로필 이미지',
-        required=False
-    )
-    bio = forms.CharField(
-        label='자기소개',
-        widget=forms.Textarea(attrs={'placeholder': '자기소개를 입력해주세요.'}),
-        required=False
-    )
     password1 = forms.CharField(
         label='비밀번호',
         widget=forms.PasswordInput(attrs={'placeholder': '비밀번호를 입력해주세요.'}),
@@ -49,19 +34,13 @@ class SignUpForm(UserCreationForm):
 
     class Meta:
         model = User
-        fields = ('school_name', 'department', 'student_id', 'nickname', 'image', 'bio', 'password1', 'password2')
+        fields = ('school_name', 'department', 'student_id', 'password1', 'password2')
 
     def clean_student_id(self):
         student_id = self.cleaned_data.get('student_id')
         if User.objects.filter(student_id=student_id).exists():
             raise forms.ValidationError('이미 사용 중인 학번(아이디)입니다.')
         return student_id
-    
-    def clean_nickname(self):
-        nickname = self.cleaned_data.get('nickname')
-        if User.objects.filter(nickname=nickname).exists():
-            raise forms.ValidationError('이미 사용 중인 닉네임입니다.')
-        return nickname
 
 class LoginForm(forms.Form):
     student_id = forms.CharField(

--- a/accounts/serializers.py
+++ b/accounts/serializers.py
@@ -5,21 +5,16 @@ from .models import User
 class RegisterSerializer(serializers.ModelSerializer):
     password = serializers.CharField(write_only=True)
     password2 = serializers.CharField(write_only=True)
-    image = serializers.ImageField(required=False)
-    bio = serializers.CharField(required=False)
-    nickname = serializers.CharField()
 
     class Meta:
         model = User
-        fields = ('school_name', 'department', 'student_id', 'nickname', 'image', 'bio', 'password', 'password2')
+        fields = ('school_name', 'department', 'student_id', 'password', 'password2')
 
     def validate(self, data):
         if data['password'] != data['password2']:
             raise serializers.ValidationError('비밀번호가 일치하지 않습니다.')
         if User.objects.filter(student_id=data['student_id']).exists():
             raise serializers.ValidationError('이미 사용 중인 학번(아이디)입니다.')
-        if User.objects.filter(nickname=data['nickname']).exists():
-            raise serializers.ValidationError('이미 사용 중인 닉네임입니다.')
         return data
 
     def create(self, validated_data):

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -12,4 +12,6 @@ urlpatterns = [
     # 마이페이지
     path('profile/', views.profile_view, name='profile'),
     path('profile/update/', views.profile_update, name='profile_update'),
+    # 닉네임 입력
+    path('set-nickname/', views.set_nickname, name='set_nickname'),
 ] 

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -6,6 +6,11 @@ from rest_framework.response import Response
 from rest_framework import status, permissions
 from .serializers import RegisterSerializer, LoginSerializer
 from django.contrib.auth.decorators import login_required
+from django import forms
+from accounts.models import User
+from quest.models import Quest
+from feed.models import Feed
+from datetime import date
 
 # Create your views here.
 
@@ -78,5 +83,51 @@ def profile_update(request):
     else:
         form = ProfileUpdateForm(instance=request.user)
     return render(request, 'accounts/profile_update.html', {'form': form})
+
+class NicknameForm(forms.ModelForm):
+    class Meta:
+        model = User
+        fields = ['nickname']
+
+@login_required
+def set_nickname(request):
+    if request.method == 'POST':
+        form = NicknameForm(request.POST, instance=request.user)
+        if form.is_valid():
+            form.save()
+            return redirect('mainpage')
+    else:
+        form = NicknameForm(instance=request.user)
+    return render(request, 'accounts/set_nickname.html', {'form': form})
+
+@login_required
+def mainpage(request):
+    # 닉네임 없으면 닉네임 입력 페이지로 리다이렉트
+    if not request.user.nickname:
+        return redirect('accounts:set_nickname')
+    # 레벨 계산(예: 100exp당 1레벨)
+    exp = getattr(request.user, 'exp', 0)
+    level = exp // 100 + 1
+    # 학교명
+    school = request.user.school_name
+    # 이번 주 퀘스트
+    today = date.today()
+    month = today.month
+    week = (today.day - 1) // 7 + 1
+    quests = Quest.objects.filter(month=month, week=week)
+    # 퀘스트 완료 여부(Feed에 인증된 quest가 3개 이상이면 완료)
+    completed_count = Feed.objects.filter(author=request.user, quest__in=quests, is_completed=True).count()
+    is_all_completed = completed_count >= 3
+    # 퀘스트 경험치 정보
+    quest_exp = sum(q.exp for q in quests)
+    context = {
+        'nickname': request.user.nickname,
+        'level': level,
+        'school': school,
+        'quests': quests,
+        'is_all_completed': is_all_completed,
+        'quest_exp': quest_exp,
+    }
+    return render(request, 'main/mainpage.html', context)
 
 


### PR DESCRIPTION
## 주요 변경사항

1. 회원가입 시 닉네임 입력 과정 제거
- 닉네임은 로그인 이후 첫 진입 시 필수 입력으로 변경
- /accounts/set-nickname/에서 입력

2. 메인페이지 정보 구성
- mainpage에서 사용자 닉네임, 레벨(User.exp), 학교명 전달
- 이번 주 퀘스트, 완료 여부, 획득 경험치 포함

3. 경험치/퀘스트 시스템 연결
- 피드 작성 시 퀘스트 인증으로 간주, 경험치 증가(추후 변경 가능)
- User 모델에 저장된 경험치 기반 레벨 계산

