### PR TITLE
fix: 친구 프로필 사진 첨부 변경 및 피드 댓글 닉네임, 사진 수정

### DIFF
--- a/feed/views.py
+++ b/feed/views.py
@@ -107,6 +107,9 @@ def feed_create(request):
         })
     return JsonResponse({'error': 'Invalid request method'}, status=400)
 
+def get_display_name(user):
+    return user.nickname if user.nickname else user.username
+
 @login_required
 def feed_detail(request, feed_id):
     feed = get_object_or_404(Feed, id=feed_id)
@@ -128,7 +131,8 @@ def feed_detail(request, feed_id):
             'is_private': feed.is_private,
             'comments': [{
                 'id': comment.id,
-                'author': comment.author.username,
+                'nickname': get_display_name(comment.author),
+                'author_image': comment.author.image.url if comment.author.image else None,
                 'content': comment.content,
                 'created_at': comment.created_at.isoformat()
             } for comment in comments]
@@ -196,15 +200,10 @@ def comment_create(request, feed_id):
             author=request.user,
             content=content
         )
-        # 사용자 이름(닉네임 우선, 없으면 이름, 없으면 username)
-        author_name = getattr(request.user, 'nickname', None) or request.user.get_full_name() or request.user.username
-        # 프로필 이미지 URL 반환 (없으면 None)
-        author_image = request.user.image.url if hasattr(request.user, 'image') and request.user.image else None
-
         return JsonResponse({
             'id': comment.id,
-            'author': author_name,
-            'author_image': author_image,
+            'nickname': get_display_name(request.user),
+            'author_image': request.user.image.url if request.user.image else None,
             'content': comment.content,
             'created_at': comment.created_at.isoformat()
         })

--- a/project/static/css/page/feedpage.css
+++ b/project/static/css/page/feedpage.css
@@ -25,6 +25,9 @@
   height: 47px;
   flex-shrink: 0;
   border-radius: 50%;
+  object-fit: cover;
+  background: #eee;
+  display: block;
 }
 
 .profile-info {

--- a/project/static/css/page/friendpage.css
+++ b/project/static/css/page/friendpage.css
@@ -80,7 +80,11 @@
   width: 42px;
   height: 42px;
   background-color: #ccc;
-  border-radius: 10px;
+  border-radius: 50%;
+  overflow: hidden;
+  object-fit: cover;
+  background-position: center;
+  background-size: cover;
 }
 
 .friend-info,

--- a/project/static/js/page/feedpage.js
+++ b/project/static/js/page/feedpage.js
@@ -387,17 +387,13 @@ document.addEventListener("DOMContentLoaded", () => {
                   commentList.innerHTML += `
                     <div class="comment-item">
                       <div class="comment-content">
-                        <img src="/static/images/profile-default.svg" class="comment-profile" />
+                        <img src="${comment.author_image || '/static/images/profile-default.svg'}" class="comment-profile" />
                         <div class="comment-text">
-                          <span class="comment-username">${
-                            comment.author
-                          }</span>
+                          <span class="comment-username">${(comment.nickname && comment.nickname.trim()) || comment.username || '익명'}</span>
                           <span class="comment-body">${comment.content}</span>
                         </div>
                       </div>
-                      <span class="comment-time">${timeSince(
-                        comment.created_at
-                      )}</span>
+                      <span class="comment-time">${timeSince(comment.created_at)}</span>
                     </div>
                   `;
                 });
@@ -464,11 +460,9 @@ document.addEventListener("DOMContentLoaded", () => {
             }
             newComment.innerHTML = `
               <div class="comment-content">
-                <img src="${
-                  data.author_image || "/static/images/profile-default.svg"
-                }" class="comment-profile" />
+                <img src="${data.author_image || '/static/images/profile-default.svg'}" class="comment-profile" />
                 <div class="comment-text">
-                  <span class="comment-username">${data.author}</span>
+                  <span class="comment-username">${(data.nickname && data.nickname.trim()) || data.username || '익명'}</span>
                   <span class="comment-body">${data.content}</span>
                 </div>
               </div>


### PR DESCRIPTION
# 🔥 Pull requests

## 👷 작업한 내용
- 친구 목록에서 프로필 사진 깨지는 현상 수정
- 피드 속 본인 및 친구 댓글에서 프로필 사진이 반영이 안되는 현상 수정
- 피드 속 본인 및 친구 댓글에서 닉네임이 반영이 안되고 학번이 출력되는 현상 수정


## 📸 스크린샷

![image](https://github.com/user-attachments/assets/d699745a-f2b8-404e-9789-d3fbfd64bb8a)
![image](https://github.com/user-attachments/assets/662ca387-dee4-4f8b-89ea-58a8ead7e29b)


## 🖥️ 주요 코드 설명
- 사용자 프로필에 표시할 이름 함수 선언
def get_display_name(user):
    return user.nickname if user.nickname else user.username
- 작성자의 표시 이름과 프로필 이미지가 저장돼 있으면 불러오는 코드
 'nickname': get_display_name(comment.author),
  'author_image': comment.author.image.url if comment.author.image else None,
- 불러와서 페이지에 불러오는 코드
<img src="${comment.author_image || '/static/images/profile-default.svg'}" class="comment-profile" />
<span class="comment-username">${(comment.nickname && comment.nickname.trim()) || comment.username || '익명'}</span>

## ✅ Check List

- [V] 사진이 불러와지는가? 
- [V] 닉네임이 불러와지는가?
